### PR TITLE
Updated dropdown menu index.tsx

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -121,7 +121,7 @@ export default function Menu() {
             <Code size={14} />
             Code
           </MenuItem>
-          <MenuItem id="link" href="https://discord.gg/vXCdddD">
+          <MenuItem id="link" href="https://discord.gg/EwFs3Pp">
             <MessageCircle size={14} />
             Discord
           </MenuItem>


### PR DESCRIPTION
The discord invite link in the dropdown menu on uniswap was dead.  I replaced it with the working on off of the docs site.

**PLEASE DO NOT SUBMIT TOKEN ADDITIONS AS PULL REQUESTS**

All token requests should be made via an issue.
