### PR TITLE
feat(swap): setting to disable multihop routing

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -6,7 +6,9 @@ import {
   useUserSlippageTolerance,
   useExpertModeManager,
   useUserDeadline,
-  useDarkModeManager
+  useDarkModeManager,
+  useDisableMultihopRouting,
+  useToggleDisableMultihopRouting
 } from '../../state/user/hooks'
 import SlippageTabs from '../SlippageTabs'
 import { RowFixed, RowBetween } from '../Row'
@@ -157,6 +159,9 @@ export default function SettingsTab() {
     }
   }, [open, toggle])
 
+  const disableMultihopRouting = useDisableMultihopRouting()
+  const toggleDisableMultihopRouting = useToggleDisableMultihopRouting()
+
   return (
     <StyledMenu ref={node}>
       <Modal isOpen={showConfirmation} onDismiss={() => setShowConfirmation(false)} maxHeight={100}>
@@ -221,6 +226,17 @@ export default function SettingsTab() {
             <Text fontWeight={600} fontSize={14}>
               Interface Settings
             </Text>
+
+            <RowBetween>
+              <RowFixed>
+                <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
+                  Disable Multihop Routing
+                </TYPE.black>
+                <QuestionHelper text="Disables swap routing through multiple tokens. You will get a worse price, but transactions will cost less gas." />
+              </RowFixed>
+              <Toggle isActive={disableMultihopRouting} toggle={toggleDisableMultihopRouting} />
+            </RowBetween>
+
             <RowBetween>
               <RowFixed>
                 <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>

--- a/src/hooks/Trades.ts
+++ b/src/hooks/Trades.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 
 import { BASES_TO_CHECK_TRADES_AGAINST, CUSTOM_BASES } from '../constants'
 import { PairState, usePairs } from '../data/Reserves'
+import { useDisableMultihopRouting } from '../state/user/hooks'
 import { wrappedCurrency } from '../utils/wrappedCurrency'
 
 import { useActiveWeb3React } from './index'
@@ -72,11 +73,14 @@ function useAllCommonPairs(currencyA?: Currency, currencyB?: Currency): Pair[] {
  */
 export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?: Currency): Trade | null {
   const allowedPairs = useAllCommonPairs(currencyAmountIn?.currency, currencyOut)
-
+  const disableMultihopRouting = useDisableMultihopRouting()
   return useMemo(() => {
     if (currencyAmountIn && currencyOut && allowedPairs.length > 0) {
       return (
-        Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, { maxHops: 3, maxNumResults: 1 })[0] ?? null
+        Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, {
+          maxHops: disableMultihopRouting ? 1 : 3,
+          maxNumResults: 1
+        })[0] ?? null
       )
     }
     return null
@@ -88,12 +92,15 @@ export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?:
  */
 export function useTradeExactOut(currencyIn?: Currency, currencyAmountOut?: CurrencyAmount): Trade | null {
   const allowedPairs = useAllCommonPairs(currencyIn, currencyAmountOut?.currency)
+  const disableMultihopRouting = useDisableMultihopRouting()
 
   return useMemo(() => {
     if (currencyIn && currencyAmountOut && allowedPairs.length > 0) {
       return (
-        Trade.bestTradeExactOut(allowedPairs, currencyIn, currencyAmountOut, { maxHops: 3, maxNumResults: 1 })[0] ??
-        null
+        Trade.bestTradeExactOut(allowedPairs, currencyIn, currencyAmountOut, {
+          maxHops: disableMultihopRouting ? 1 : 3,
+          maxNumResults: 1
+        })[0] ?? null
       )
     }
     return null

--- a/src/hooks/Trades.ts
+++ b/src/hooks/Trades.ts
@@ -84,7 +84,7 @@ export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?:
       )
     }
     return null
-  }, [allowedPairs, currencyAmountIn, currencyOut])
+  }, [allowedPairs, currencyAmountIn, currencyOut, disableMultihopRouting])
 }
 
 /**
@@ -104,5 +104,5 @@ export function useTradeExactOut(currencyIn?: Currency, currencyAmountOut?: Curr
       )
     }
     return null
-  }, [allowedPairs, currencyIn, currencyAmountOut])
+  }, [currencyIn, currencyAmountOut, allowedPairs, disableMultihopRouting])
 }

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -14,9 +14,11 @@ export interface SerializedPair {
 }
 
 export const updateVersion = createAction<void>('updateVersion')
+
 export const updateMatchesDarkMode = createAction<{ matchesDarkMode: boolean }>('updateMatchesDarkMode')
 export const updateUserDarkMode = createAction<{ userDarkMode: boolean }>('updateUserDarkMode')
 export const updateUserExpertMode = createAction<{ userExpertMode: boolean }>('updateUserExpertMode')
+export const updateMultihopRouting = createAction<{ multihopRouting: boolean }>('updateMultihopRouting')
 export const updateUserSlippageTolerance = createAction<{ userSlippageTolerance: number }>(
   'updateUserSlippageTolerance'
 )

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -14,6 +14,7 @@ import {
   removeSerializedToken,
   SerializedPair,
   SerializedToken,
+  updateMultihopRouting,
   updateUserDarkMode,
   updateUserDeadline,
   updateUserExpertMode,
@@ -70,6 +71,20 @@ export function useDarkModeManager(): [boolean, () => void] {
 
 export function useIsExpertMode(): boolean {
   return useSelector<AppState, AppState['user']['userExpertMode']>(state => state.user.userExpertMode)
+}
+
+export function useDisableMultihopRouting(): boolean {
+  return useSelector<AppState, AppState['user']['disableMultihopRouting']>(
+    state => state.user.disableMultihopRouting ?? false
+  )
+}
+
+export function useToggleDisableMultihopRouting(): () => void {
+  const dispatch = useDispatch<AppDispatch>()
+  const current = useDisableMultihopRouting()
+  return useCallback(() => {
+    dispatch(updateMultihopRouting({ multihopRouting: !current }))
+  }, [current, dispatch])
 }
 
 export function useExpertModeManager(): [boolean, () => void] {

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -13,7 +13,8 @@ import {
   updateVersion,
   updateUserExpertMode,
   updateUserSlippageTolerance,
-  updateUserDeadline
+  updateUserDeadline,
+  updateMultihopRouting
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
@@ -32,6 +33,9 @@ export interface UserState {
 
   // deadline set by user in minutes, used in all txns
   userDeadline: number
+
+  // whether the interface will try to route swaps through multiple tokens
+  disableMultihopRouting: boolean
 
   tokens: {
     [chainId: number]: {
@@ -66,6 +70,7 @@ export const initialState: UserState = {
   userExpertMode: false,
   userSlippageTolerance: INITIAL_ALLOWED_SLIPPAGE,
   userDeadline: DEFAULT_DEADLINE_FROM_NOW,
+  disableMultihopRouting: false,
   tokens: {},
   pairs: {},
   timestamp: currentTimestamp()
@@ -84,6 +89,10 @@ export default createReducer(initialState, builder =>
         state.userDeadline = DEFAULT_DEADLINE_FROM_NOW
       }
 
+      if (typeof state.disableMultihopRouting !== 'boolean') {
+        state.disableMultihopRouting = false
+      }
+
       state.lastUpdateVersionTimestamp = currentTimestamp()
     })
     .addCase(updateUserDarkMode, (state, action) => {
@@ -100,6 +109,10 @@ export default createReducer(initialState, builder =>
     })
     .addCase(updateUserSlippageTolerance, (state, action) => {
       state.userSlippageTolerance = action.payload.userSlippageTolerance
+      state.timestamp = currentTimestamp()
+    })
+    .addCase(updateMultihopRouting, (state, action) => {
+      state.disableMultihopRouting = action.payload.multihopRouting
       state.timestamp = currentTimestamp()
     })
     .addCase(updateUserDeadline, (state, action) => {


### PR DESCRIPTION
some ux considerations:
- this persists between swaps, and may be confusing when you can't make a swap on v2 because of the setting being turned on
- a more expressive setting would be configuring the max # of hops, e.g. 2 would sometimes be better than 1 or 3
- this may be better suited for expert mode only