### PR TITLE
Replace CoinGecko tokens list with all.json

### DIFF
--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -12,7 +12,7 @@ export const DEFAULT_LIST_OF_LISTS: string[] = [
   'stablecoin.cmc.eth',
   'tokenlist.zerion.eth',
   'tokenlist.aave.eth',
-  'https://www.coingecko.com/tokens_list/uniswap/defi_100/v_0_0_0.json',
+  'https://tokens.coingecko.com/uniswap/all.json',
   'https://app.tryroll.com/tokens.json',
   'https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json',
   'https://defiprime.com/defiprime.tokenlist.json',


### PR DESCRIPTION
Based on https://github.com/Uniswap/token-lists/issues/17

This PR proposes to replace the CoinGecko tokens list with the `all.json` which is more up to date and complete than the initial version