### PR TITLE
add conditional tokens list

### DIFF
--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -17,4 +17,5 @@ export const DEFAULT_LIST_OF_LISTS: string[] = [
   'https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json',
   'https://defiprime.com/defiprime.tokenlist.json',
   'https://umaproject.org/uma.tokenlist.json'
+  'https://raw.githubusercontent.com/gnosis/conditional-tokens-list/main/conditional-token-list.json'
 ]


### PR DESCRIPTION
Gnosis' conditional tokens are ERC1155 compatible. We have an [ERC20 wrapper](https://github.com/gnosis/1155-to-20) for the tokens so they can be traded one AMMs that only support ERC20. One feature of the list is that it gives each of the tokens identical names and symbols. So Gnosis would like to provide a curated list of these wrapped tokens.