### PR TITLE
README typo in developing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ yarn start
 To have the interface default to a different network when a wallet is not connected:
 
 1. Make a copy of `.env` named `.env.local`
-2. Change `REACT_APP_NETWORK_ID` to `"{YOUR_NETWORK_ID}"`
+2. Change `REACT_APP_CHAIN_ID` to `"{YOUR_NETWORK_ID}"`
 3. Change `REACT_APP_NETWORK_URL` to e.g. `"https://{YOUR_NETWORK_ID}.infura.io/v3/{YOUR_INFURA_KEY}"` 
 
 Note that the interface only works on testnets where both 


### PR DESCRIPTION
README says to update REACT_APP_NETWORK_ID in .env.local, but REACT_APP_CHAIN_ID used throughout app.

Also, can't get it to work using (1) my own Infura key or (2) running on something other than localhost:3000 (e.g. failing on localhost:3002)