### PR TITLE
improve displayed proposal end time accuracy

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -20,8 +20,10 @@ export const MKR = new Token(ChainId.MAINNET, '0x9f8F72aA9304c8B593d555F12eF6589
 export const AMPL = new Token(ChainId.MAINNET, '0xD46bA6D942050d489DBd938a2C909A5d5039A161', 9, 'AMPL', 'Ampleforth')
 export const WBTC = new Token(ChainId.MAINNET, '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', 18, 'WBTC', 'Wrapped BTC')
 
-// TODO this is only approximate, it's actually based on blocks
-export const PROPOSAL_LENGTH_IN_DAYS = 7
+// Block time here is slightly higher (~1s) than average in order to avoid ongoing proposals past the displayed time
+export const AVERAGE_BLOCK_TIME_IN_SECS = 14
+export const PROPOSAL_LENGTH_IN_BLOCKS = 40_320
+export const PROPOSAL_LENGTH_IN_SECS = AVERAGE_BLOCK_TIME_IN_SECS * PROPOSAL_LENGTH_IN_BLOCKS
 
 export const GOVERNANCE_ADDRESS = '0x5e4be8Bc9637f0EAA1A755019e06A68ce081D58F'
 

--- a/src/pages/Vote/VotePage.tsx
+++ b/src/pages/Vote/VotePage.tsx
@@ -16,7 +16,7 @@ import ReactMarkdown from 'react-markdown'
 import VoteModal from '../../components/vote/VoteModal'
 import { TokenAmount, JSBI } from '@uniswap/sdk'
 import { useActiveWeb3React } from '../../hooks'
-import { PROPOSAL_LENGTH_IN_DAYS, COMMON_CONTRACT_NAMES, UNI, ZERO_ADDRESS } from '../../constants'
+import { PROPOSAL_LENGTH_IN_SECS, COMMON_CONTRACT_NAMES, UNI, ZERO_ADDRESS } from '../../constants'
 import { isAddress, getEtherscanLink } from '../../utils'
 import { ApplicationModal } from '../../state/application/actions'
 import { useModalOpen, useToggleDelegateModal, useToggleVoteModal } from '../../state/application/hooks'
@@ -122,7 +122,7 @@ export default function VotePage({
   // get and format date from data
   const startTimestamp: number | undefined = useTimestampFromBlock(proposalData?.startBlock)
   const endDate: DateTime | undefined = startTimestamp
-    ? DateTime.fromSeconds(startTimestamp).plus({ days: PROPOSAL_LENGTH_IN_DAYS })
+    ? DateTime.fromSeconds(startTimestamp).plus({ seconds: PROPOSAL_LENGTH_IN_SECS })
     : undefined
   const now: DateTime = DateTime.local()
 


### PR DESCRIPTION
Proposals currently last 40,320 blocks, which equates to exactly 7 days at 15s block times.

However, the [Muir Glacier fork](https://blog.ethereum.org/2019/12/23/ethereum-muir-glacier-upgrade-announcement/) in early 2020 decreased the average block time to [somewhere between 13-13.5s](https://etherscan.io/chart/blocktime). This equates to proposals lasting approximately 6.5 days or less. This may confuse people who rely on the UI to wait until the last minute to vote on a proposal.

This PR adds a more accurate (~10%) time when displaying the approximate end of the proposal. It leaves room for variance in block times by assuming 14s block times instead of the more accurate 13-13.5s so that the proposal display time has never passed before a proposal is actually over.