### PR TITLE
Remove title parsing from description output

### DIFF
--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -124,7 +124,7 @@ export function useAllProposalData() {
         const formattedProposal: ProposalData = {
           id: allProposals[i]?.result?.id.toString(),
           title: formattedEvents[i].description?.split(/# |\n/g)[1] || 'Untitled',
-          description: formattedEvents[i].description?.split(/# /)[1] || 'No description.',
+          description: formattedEvents[i].description || 'No description.',
           proposer: allProposals[i]?.result?.proposer,
           status: enumerateProposalState(allProposalStates[i]?.result?.[0]) ?? 'Undetermined',
           forCount: parseFloat(ethers.utils.formatUnits(allProposals[i]?.result?.forVotes.toString(), 18)),


### PR DESCRIPTION
The current implementation attempts to parse out the title from the description in the event logs, in the spirit of returning `title` and `description` as separate parsed out fields.

Unfortunately, the current implementation is quite fragile to the precise way in which the description is formatted, leading to situations where the returned description is improperly formatted — or not present at all (as demonstrated [here](https://app.uniswap.org/#/vote/2))