### PR TITLE
Allow absolute imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "jsx": "preserve",
     "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["react-spring", "jest"]
+    "types": ["react-spring", "jest"],
+    "baseUrl": "src"
   },
   "exclude": ["node_modules", "cypress"],
   "include": ["./src/**/*.ts", "./src/**/*.tsx", "src/components/Confetti/index.js"]


### PR DESCRIPTION
Closes #1184

This PR sets `src` as `baseUrl` for typescript. This way, you can use absolut paths for importing. 

For example:
```
// You can change this
// import Header from '../components/Header'

// into this
import Header from 'components/Header'
```

For context https://create-react-app.dev/docs/importing-a-component