### PR TITLE
fix(list popup): big token list updates scroll issue

### DIFF
--- a/src/components/Popups/ListUpdatePopup.tsx
+++ b/src/components/Popups/ListUpdatePopup.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import ReactGA from 'react-ga'
 import { useDispatch } from 'react-redux'
 import { Text } from 'rebass'
+import styled from 'styled-components'
 import { AppDispatch } from '../../state'
 import { useRemovePopup } from '../../state/application/hooks'
 import { acceptListUpdate } from '../../state/lists/actions'
@@ -11,6 +12,11 @@ import listVersionLabel from '../../utils/listVersionLabel'
 import { ButtonSecondary } from '../Button'
 import { AutoColumn } from '../Column'
 import { AutoRow } from '../Row'
+
+export const ChangesList = styled.ul`
+  max-height: 400px;
+  overflow: auto;
+`
 
 export default function ListUpdatePopup({
   popKey,
@@ -64,7 +70,7 @@ export default function ListUpdatePopup({
                 An update is available for the token list &quot;{oldList.name}&quot; (
                 {listVersionLabel(oldList.version)} to {listVersionLabel(newList.version)}).
               </Text>
-              <ul>
+              <ChangesList>
                 {tokensAdded.length > 0 ? (
                   <li>
                     {tokensAdded.map((token, i) => (
@@ -88,7 +94,7 @@ export default function ListUpdatePopup({
                   </li>
                 ) : null}
                 {numTokensChanged > 0 ? <li>{numTokensChanged} tokens updated</li> : null}
-              </ul>
+              </ChangesList>
             </div>
             <AutoRow>
               <div style={{ flexGrow: 1, marginRight: 12 }}>


### PR DESCRIPTION
Depending on how long a user waits between visits to uniswap, changes to the selected token list can accumulate. The current popup does not allow scrolling so the user can end up in a situation where they cannot accept or decline the most recent list because the buttons are outside of the view port.

This PR puts a limit on the height of the pop up and enables scroll if needed.

Before: 
![Screenshot from 2020-11-19 22-24-19](https://user-images.githubusercontent.com/9872474/99744767-1551db80-2ab7-11eb-97a2-24e144f0f242.png)

After:
![Screenshot from 2020-11-19 22-22-46](https://user-images.githubusercontent.com/9872474/99744777-1c78e980-2ab7-11eb-85dd-d1b39cda5f4e.png)
