### PR TITLE
Add uEth as routing pair. Add tokenlist.ulock.eth to tokenlists.

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -19,6 +19,7 @@ export const COMP = new Token(ChainId.MAINNET, '0xc00e94Cb662C3520282E6f57172140
 export const MKR = new Token(ChainId.MAINNET, '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2', 18, 'MKR', 'Maker')
 export const AMPL = new Token(ChainId.MAINNET, '0xD46bA6D942050d489DBd938a2C909A5d5039A161', 9, 'AMPL', 'Ampleforth')
 export const WBTC = new Token(ChainId.MAINNET, '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', 8, 'WBTC', 'Wrapped BTC')
+export const UETH = new Token(ChainId.MAINNET, '0x395C8dB957d743a62Ac3aAAa4574553bcf2380b3', 8, 'UETH', 'uLock.eth')
 
 // Block time here is slightly higher (~1s) than average in order to avoid ongoing proposals past the displayed time
 export const AVERAGE_BLOCK_TIME_IN_SECS = 14
@@ -60,7 +61,7 @@ const WETH_ONLY: ChainTokenList = {
 // used to construct intermediary pairs for trading
 export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
   ...WETH_ONLY,
-  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT, COMP, MKR]
+  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT, COMP, MKR, UETH]
 }
 
 /**
@@ -82,7 +83,7 @@ export const SUGGESTED_BASES: ChainTokenList = {
 // used to construct the list of all pairs we consider by default in the frontend
 export const BASES_TO_TRACK_LIQUIDITY_FOR: ChainTokenList = {
   ...WETH_ONLY,
-  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT]
+  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT, UETH]
 }
 
 export const PINNED_PAIRS: { readonly [chainId in ChainId]?: [Token, Token][] } = {

--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -16,5 +16,6 @@ export const DEFAULT_LIST_OF_LISTS: string[] = [
   'https://app.tryroll.com/tokens.json',
   'https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json',
   'https://defiprime.com/defiprime.tokenlist.json',
-  'https://umaproject.org/uma.tokenlist.json'
+  'https://umaproject.org/uma.tokenlist.json',
+  'tokenlist.ulock.eth'
 ]


### PR DESCRIPTION
uETH allows safely creating tokens with high liquidity on Uniswap for no cost. All circulating uETH is backed 1:1 by ETH, but uETH permanently locked in Uniswap is not redeemable. This allows the free creation of arbitrary amounts of liquidity without any protocol upgrades to Uniswap. More information is available at [ulock.eth](https://ulock.eth).

This PR adds uETH as a routing pair for the Uniswap app, allowing new users to trade uETH/xyz pairs without using the uEth wrapping contract.

Without uETH as a routing pair, malicious liquidity providers can create low liquidity WETH/xyz pairs then withdraw the liquidity after the WETH/xyz price exceeds the uETH/xyz price.