### PR TITLE
feat: allow overriding proposals in the UI

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,6 +7,8 @@ export const ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
+export { PRELOADED_PROPOSALS } from './proposals'
+
 // a list of tokens by chain
 type ChainTokenList = {
   readonly [chainId in ChainId]: Token[]

--- a/src/constants/proposals/index.ts
+++ b/src/constants/proposals/index.ts
@@ -1,6 +1,4 @@
 import { UNISWAP_GRANTS } from './uniswap_grants'
 
 // Proposals are 0-indexed
-export const PRELOADED_PROPOSALS = new Map([
-  [2, UNISWAP_GRANTS],
-])
+export const PRELOADED_PROPOSALS = new Map([[2, UNISWAP_GRANTS]])

--- a/src/constants/proposals/index.ts
+++ b/src/constants/proposals/index.ts
@@ -1,0 +1,6 @@
+import { UNISWAP_GRANTS } from './uniswap_grants'
+
+// Proposals are 0-indexed
+export const PRELOADED_PROPOSALS = new Map([
+  [2, UNISWAP_GRANTS],
+])

--- a/src/constants/proposals/uniswap_grants.ts
+++ b/src/constants/proposals/uniswap_grants.ts
@@ -1,4 +1,4 @@
-export const UNISWAP_GRANTS: string = `# Uniswap Grants Program v0.1
+export const UNISWAP_GRANTS = `# Uniswap Grants Program v0.1
 
 *co-authored with [Ken Ng](https://twitter.com/nkennethk?lang=en)*
 

--- a/src/constants/proposals/uniswap_grants.ts
+++ b/src/constants/proposals/uniswap_grants.ts
@@ -1,0 +1,106 @@
+export const UNISWAP_GRANTS: string = `# Uniswap Grants Program v0.1
+
+*co-authored with [Ken Ng](https://twitter.com/nkennethk?lang=en)*
+
+## Summary:
+
+**This post outlines a framework for funding Uniswap ecosystem development with grants from the[ UNI Community Treasury](https://uniswap.org/blog/uni/).** The program starts small—sponsoring hackathons, [for example](https://gov.uniswap.org/c/proposal-discussion/5)—but could grow in significance over time (with renewals approved by governance) to fund core protocol development. Grants administration is a subjective process that cannot be easily automated, and thus we propose a nimble committee of 6 members —1 lead and 5 reviewers—to deliver an efficient, predictable process to applicants, such that funding can be administered without having to put each application to a vote. We propose the program start with an initial cap of $750K per quarter and a limit of 2 quarters before renewal—a sum that we feel is appropriate for an MVP relative to the size of the treasury that UNI token holders are entrusted with allocating.
+
+**Purpose:**
+
+**The mission of the UGP is to provide valuable resources to help grow the Uniswap ecosystem.** Through public discourse and inbound applications, the community will get first-hand exposure to identify and respond to the most pressing needs of the ecosystem, as well as the ability to support innovative projects expanding the capabilities of Uniswap. By rewarding talent early with developer incentives, bounties, and infrastructure support, UGP acts as a catalyst for growth and helps to maintain Uniswap as a nexus for DeFi on Ethereum.
+
+**Quarterly Budget:**
+
+* Max quarterly budget of up to $750k
+* Budget and caps to be assessed every six months
+
+**Grant Allocation Committee:**
+
+* Of 6 committee members: 1 lead and 5 reviewers
+* Each committee has a term of 2 quarters (6 months) after which the program needs to be renewed by UNI governance
+* Committee functions as a 4 of 5 multi-sig
+
+**Committee Members**
+
+While the goals and priorities of the grant program will be thoroughly discussed and reviewed by the community through public discourse, **the decision to start UGP by operating as a small committee is to ensure that the application and decision process will be efficient and predictable, so applicants have clear objectives and timely decisions.**
+
+Starting with just six members enables the committee to efficiently fund projects with tight feedback loops and rapid iterations. The purpose of this committee would be to test the hypothesis that the Grants Program can successfully provide value for the UNI ecosystem before scaling the program.
+
+**We suggest the grants program is administered by a single lead. Here we propose Kenneth Ng, a co-author of this post**. Ken has helped grow the Ethereum Foundation Grants Program over the last two years in establishing high level priorities and adapting for the ecosystems needs.
+
+**The other 5 committee members should be thought of as “reviewers” — UNI community members who will keep the grants program functional by ensuring Ken is leading effectively and, of course, not absconding with funds.** Part of the reviewers job is to hold the program accountable for success (defined below) and/or return any excess funds to the UNI treasury. Reviewers are not compensated as part of this proposal as we expect their time commitment to be minimal. Compensation for the lead role is discussed below, as we expect this to be a labor intensive role.
+
+**Program Lead:** [Ken Ng](https://twitter.com/nkennethk?lang=en) (HL Creative Corp)
+*Ecosystem Support Program at the Ethereum Foundation*
+
+1. Reviewer: [Jesse Walden](https://twitter.com/jessewldn) (o/b/o Unofficial LLC dba [Variant Fund](http://twitter.com/variantfund))
+*Founder and Investor at Variant Fund (holds UNI)*
+
+2. Reviewer: [Monet Supply](https://twitter.com/MonetSupply)
+*Risk Analyst at MakerDAO*
+
+3. Reviewer: [Robert Leshner](https://twitter.com/rleshner)
+*Founder and CEO of Compound Finance*
+
+4. Reviewer: [Kain Warwick](https://twitter.com/kaiynne)
+*Founder of Synthetix*
+
+5. Reviewer: [Ashleigh Schap](https://twitter.com/ashleighschap)
+*Growth Lead, Uniswap (Company)*
+
+## Methodology
+
+**1.1 Budget**
+
+This proposal recommends a max cap of $750K per quarter, with the ability to reevaluate biannually at each epoch (two fiscal quarters). While the UGP Grants Committee will be the decision makers around individual grants, respective budgets, roadmaps, and milestones, any top-level changes to UGP including epochs and max cap, will require full community quorum (4% approval).
+
+The UGP will be funded by the UNI treasury according to the[ release schedule](https://uniswap.org/blog/uni/) set out by the Uniswap team, whereby 43% of the UNI treasury is released over a four-year timeline. In Year 1 this will total to 172,000,000 UNI (~$344M as of writing).
+
+Taking into consideration the current landscape of ecosystem funding across Ethereum, the community would be hard-pressed to allocate even 5% of Year 1’s treasury. For context Gitcoin CLR Round 7 distributed $725k ($450k in matched) across 857 projects and YTD, Moloch has granted just under $200k but in contrast, the EF has committed to somewhere in the 8 figure range.
+
+**1.2 Committee Compensation**
+
+Operating a successful grants program takes considerable time and effort. Take, for instance, the EF Ecosystem Support Program, which has awarded grants since 2018, consists of an internal team at the Foundation as well as an ever increasing roster of community advisors in order to keep expanding and adapting to best serve the needs of the Ethereum ecosystem. While the structure of the allocation committee has six members, we propose that only the lead will be remunerated for their work in establishing the initial processes, vetting applications, and managing the program overall as this role is expected to be time consuming if the program is to be succesful. We propose that the other committee members be unpaid UNI ecosystem stakeholders who have an interest in seeing the protocol ecosystem continue to operate and grow.
+
+**We propose the lead be compensated 25 UNI/hr (approximately $100 USD at time of this writing) capped at 30 hours/week. This compensation, along with the quarterly budget, will be allocated to the UGP multisig from the UNI treasury**. In keeping with the committee’s commitment to the community, hours and duties will be logged publicly and transparently .
+
+**2.1 Priorities**
+
+Initially, the program aims to start narrow in scope, funding peripheral ecosystem initiatives, such as targeted bounties, hackathon sponsorships, and other low-stakes means of building out the Uniswap developer ecosystem. Over time, if the program proves effective, the grant allocations can grow in scope to include, for example, improved frontends, trading interfaces, and eventually, core protocol development.
+
+![|624x199](upload://vNP0APCOjiwQMurCmYI47cTLklc.png)
+
+With the initial priorities in mind, some effective measures for quick successes might look like:
+
+* Total number of projects funded
+* Quarterly increase in applications
+* Project engagement post-event/funding
+* Overall community engagement/sentiment
+
+**2.2 Timeline**
+
+In keeping with the fast pace of the UNI ecosystem, we organize time in epochs, or two calendar quarters. Each epoch will see two funding rounds, one per quarter, after which the community can review and create proposals to improve or revamp the program as they deem fit.
+
+**![|624x245](upload://n56TSh5X3mt4TSqVVMFhbnZM0eM.png)**
+
+**Rolling Wave 1 & 2 Applications**
+
+* Starting in Q1 2021, UGP will start accepting applications for events looking for support in the form of bounties or prizes that in parallel can be proactively sourced. During these first two waves of funding projects, the allocation committee lead can begin laying out guardrails for continued funding
+
+* Considering the immediate feedback loops for the first epoch, we expect these allocation decisions to be discussed and reviewed by the larger community. Should this not be of value, the community can submit a formal governance proposal to change any piece of UGP that was not effective
+
+**Wave 3 & Beyond**
+
+* Beginning with Wave 3, there should have been enough time with impactful projects funded to be considered for follow-on funding, should it make sense. In the same vein, projects within scope will be expanded to also include those working on integrations and and other key components.
+
+* Beyond the second epoch, as the community helps to review and help adapt UGP to be most effective, the scope will continue to grow in order to accommodate the state of the ecosystem including that of core protocol improvements
+
+## Conclusion:
+
+**If this proposal is successfully approved, UGP will start accepting applications on a rolling basis beginning at the start of 2021.** With the phases and priorities laid out above, UGP will aim to make a significant impact by catalyzing growth and innovation in the UNI ecosystem.
+
+**This program is meant to be the simplest possible MVP of a Uniswap Ecosystem Grants initiative.** While the multi-sig committee comes with trust assumptions about the members, our hope is the community will approve this limited engagement to get the ball rolling in an efficient structure. **After the first epoch (2 fiscal quarters) the burden of proof will be on UGP to show empirical evidence that the program is worth continuing in its existing form and will submit to governance to renew treasury funding.**
+
+If this program proves successful, we hope it will inspire others to follow suit and create their own funding committees for allocating treasury capital—ideally with different specializations.
+`

--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -1,4 +1,4 @@
-import { UNI } from './../../constants/index'
+import { UNI, PRELOADED_PROPOSALS } from './../../constants/index'
 import { TokenAmount } from '@uniswap/sdk'
 import { isAddress } from 'ethers/lib/utils'
 import { useGovernanceContract, useUniContract } from '../../hooks/useContract'
@@ -121,10 +121,11 @@ export function useAllProposalData() {
         return Boolean(p.result) && Boolean(allProposalStates[i]?.result) && Boolean(formattedEvents[i])
       })
       .map((p, i) => {
+        const description = PRELOADED_PROPOSALS.get(allProposals.length - i - 1) || formattedEvents[i].description
         const formattedProposal: ProposalData = {
           id: allProposals[i]?.result?.id.toString(),
-          title: formattedEvents[i].description?.split(/# |\n/g)[1] || 'Untitled',
-          description: formattedEvents[i].description || 'No description.',
+          title: description?.split(/# |\n/g)[1] || 'Untitled',
+          description: description || 'No description.',
           proposer: allProposals[i]?.result?.proposer,
           status: enumerateProposalState(allProposalStates[i]?.result?.[0]) ?? 'Undetermined',
           forCount: parseFloat(ethers.utils.formatUnits(allProposals[i]?.result?.forVotes.toString(), 18)),


### PR DESCRIPTION
As title. Also includes the Uniswap grants proposal, since its description was fudged. https://gov.uniswap.org/t/rfc-uniswap-grants-program-v0-1/9081.

Overriding a proposal is as simple as adding it in the `constants/proposals` directory and exporting it via the PRELOADED_PROPOSALS map with its proposalId.