### PR TITLE
fix (string parsing error): catch error in bytes32 string parsing

### DIFF
--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -8,6 +8,7 @@ import { isAddress } from '../utils'
 
 import { useActiveWeb3React } from './index'
 import { useBytes32TokenContract, useTokenContract } from './useContract'
+import { arrayify } from 'ethers/lib/utils'
 
 export function useAllTokens(): { [address: string]: Token } {
   const { chainId } = useActiveWeb3React()
@@ -40,10 +41,12 @@ export function useIsUserAddedToken(currency: Currency): boolean {
 
 // parse a name or symbol from a token response
 const BYTES32_REGEX = /^0x[a-fA-F0-9]{64}$/
+
 function parseStringOrBytes32(str: string | undefined, bytes32: string | undefined, defaultValue: string): string {
   return str && str.length > 0
     ? str
-    : bytes32 && BYTES32_REGEX.test(bytes32)
+    : // need to check for proper bytes string and valid terminator
+    bytes32 && BYTES32_REGEX.test(bytes32) && arrayify(bytes32)[31] === 0
     ? parseBytes32String(bytes32)
     : defaultValue
 }


### PR DESCRIPTION
- if you paste certain tokens the ethers string parsing library errors out because no null terminator is found in symbol or name 
- example -> https://etherscan.io/address/0xbb9bc244d798123fde783fcc1c72d3bb8c189413#readContract
- see parsing logic here https://github.com/ethers-io/ethers.js/blob/master/packages/strings/src.ts/bytes32.ts