### PR TITLE
fix(modal cutoff, lists): make modal scrollable on small screens, fix typo, auto update all lists

### DIFF
--- a/src/components/SearchModal/ImportList.tsx
+++ b/src/components/SearchModal/ImportList.tsx
@@ -24,6 +24,7 @@ import { useAllLists } from 'state/lists/hooks'
 const Wrapper = styled.div`
   position: relative;
   width: 100%;
+  overflow: auto;
 `
 
 interface ImportProps {

--- a/src/components/SearchModal/ImportToken.tsx
+++ b/src/components/SearchModal/ImportToken.tsx
@@ -103,7 +103,7 @@ export function ImportToken({ tokens, onBack, onDismiss, handleCurrencySelect }:
                     <RowFixed>
                       <AlertTriangle stroke={theme.red1} size="10px" />
                       <TYPE.body color={theme.red1} ml="4px" fontSize="10px" fontWeight={500}>
-                        Unkown Source
+                        Unknown Source
                       </TYPE.body>
                     </RowFixed>
                   </WarningWrapper>

--- a/src/components/SearchModal/ImportToken.tsx
+++ b/src/components/SearchModal/ImportToken.tsx
@@ -22,6 +22,7 @@ import { PaddedColumn, Checkbox } from './styleds'
 const Wrapper = styled.div`
   position: relative;
   width: 100%;
+  overflow: auto;
 `
 
 const WarningWrapper = styled(Card)<{ highWarning: boolean }>`

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -1,5 +1,4 @@
 import { useAllLists } from 'state/lists/hooks'
-import { UNSUPPORTED_LIST_URLS } from './../../constants/lists'
 import { getVersionUpgrade, minVersionBump, VersionUpgrade } from '@uniswap/token-lists'
 import { useCallback, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
@@ -67,11 +66,9 @@ export default function Updater(): null {
             }
             break
 
+          // update any active or inactive lists
           case VersionUpgrade.MAJOR:
-            // accept update if list is active or list in background
-            if (activeListUrls?.includes(listUrl) || UNSUPPORTED_LIST_URLS.includes(listUrl)) {
-              dispatch(acceptListUpdate(listUrl))
-            }
+            dispatch(acceptListUpdate(listUrl))
         }
       }
     })


### PR DESCRIPTION
- before only active lists were being updated, update all if loaded into lists
- make import token and list views scrollable on small screens
- fix typo in import 