### PR TITLE
Use BigNumber for userDeadline

### DIFF
--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useContext } from 'react'
 import styled, { ThemeContext } from 'styled-components'
+import { BigNumber } from '@ethersproject/bignumber'
 
 import QuestionHelper from '../QuestionHelper'
 import { TYPE } from '../../theme'
@@ -88,8 +89,8 @@ const SlippageEmojiContainer = styled.span`
 export interface SlippageTabsProps {
   rawSlippage: number
   setRawSlippage: (rawSlippage: number) => void
-  deadline: number
-  setDeadline: (deadline: number) => void
+  deadline: BigNumber
+  setDeadline: (deadline: BigNumber) => void
 }
 
 export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, setDeadline }: SlippageTabsProps) {
@@ -102,7 +103,7 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
 
   const slippageInputIsValid =
     slippageInput === '' || (rawSlippage / 100).toFixed(2) === Number.parseFloat(slippageInput).toFixed(2)
-  const deadlineInputIsValid = deadlineInput === '' || (deadline / 60).toString() === deadlineInput
+  const deadlineInputIsValid = deadlineInput === '' || deadline.div(60).toString() === deadlineInput
 
   let slippageError: SlippageError | undefined
   if (slippageInput !== '' && !slippageInputIsValid) {
@@ -137,9 +138,9 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
     setDeadlineInput(value)
 
     try {
-      const valueAsInt: number = Number.parseInt(value) * 60
-      if (!Number.isNaN(valueAsInt) && valueAsInt > 0) {
-        setDeadline(valueAsInt)
+      const valueAsBN = BigNumber.from(value).mul(60)
+      if (valueAsBN.gt(0)) {
+        setDeadline(valueAsBN)
       }
     } catch {}
   }
@@ -235,9 +236,9 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
             <Input
               color={!!deadlineError ? 'red' : undefined}
               onBlur={() => {
-                parseCustomDeadline((deadline / 60).toString())
+                parseCustomDeadline(deadline.div(60).toString())
               }}
-              placeholder={(deadline / 60).toString()}
+              placeholder={deadline.div(60).toString()}
               value={deadlineInput}
               onChange={e => parseCustomDeadline(e.target.value)}
             />

--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -89,8 +89,8 @@ const SlippageEmojiContainer = styled.span`
 export interface SlippageTabsProps {
   rawSlippage: number
   setRawSlippage: (rawSlippage: number) => void
-  deadline: BigNumber
-  setDeadline: (deadline: BigNumber) => void
+  deadline: string
+  setDeadline: (deadline: string) => void
 }
 
 export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, setDeadline }: SlippageTabsProps) {
@@ -103,7 +103,11 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
 
   const slippageInputIsValid =
     slippageInput === '' || (rawSlippage / 100).toFixed(2) === Number.parseFloat(slippageInput).toFixed(2)
-  const deadlineInputIsValid = deadlineInput === '' || deadline.div(60).toString() === deadlineInput
+  const deadlineInputIsValid =
+    deadlineInput === '' ||
+    BigNumber.from(deadline)
+      .div(60)
+      .toString() === deadlineInput
 
   let slippageError: SlippageError | undefined
   if (slippageInput !== '' && !slippageInputIsValid) {
@@ -140,7 +144,7 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
     try {
       const valueAsBN = BigNumber.from(value).mul(60)
       if (valueAsBN.gt(0)) {
-        setDeadline(valueAsBN)
+        setDeadline(valueAsBN.toString())
       }
     } catch {}
   }
@@ -236,9 +240,15 @@ export default function SlippageTabs({ rawSlippage, setRawSlippage, deadline, se
             <Input
               color={!!deadlineError ? 'red' : undefined}
               onBlur={() => {
-                parseCustomDeadline(deadline.div(60).toString())
+                parseCustomDeadline(
+                  BigNumber.from(deadline)
+                    .div(60)
+                    .toString()
+                )
               }}
-              placeholder={deadline.div(60).toString()}
+              placeholder={BigNumber.from(deadline)
+                .div(60)
+                .toString()}
               value={deadlineInput}
               onChange={e => parseCustomDeadline(e.target.value)}
             />

--- a/src/hooks/useTransactionDeadline.ts
+++ b/src/hooks/useTransactionDeadline.ts
@@ -6,7 +6,7 @@ import useCurrentBlockTimestamp from './useCurrentBlockTimestamp'
 
 // combines the block timestamp with the user setting to give the deadline that should be used for any submitted transaction
 export default function useTransactionDeadline(): BigNumber | undefined {
-  const ttl = useSelector<AppState, BigNumber>(state => state.user.userDeadline)
+  const ttl = useSelector<AppState, string>(state => state.user.userDeadline)
   const blockTimestamp = useCurrentBlockTimestamp()
   return useMemo(() => {
     if (blockTimestamp && ttl) return blockTimestamp.add(ttl)

--- a/src/hooks/useTransactionDeadline.ts
+++ b/src/hooks/useTransactionDeadline.ts
@@ -6,7 +6,7 @@ import useCurrentBlockTimestamp from './useCurrentBlockTimestamp'
 
 // combines the block timestamp with the user setting to give the deadline that should be used for any submitted transaction
 export default function useTransactionDeadline(): BigNumber | undefined {
-  const ttl = useSelector<AppState, number>(state => state.user.userDeadline)
+  const ttl = useSelector<AppState, BigNumber>(state => state.user.userDeadline)
   const blockTimestamp = useCurrentBlockTimestamp()
   return useMemo(() => {
     if (blockTimestamp && ttl) return blockTimestamp.add(ttl)

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from '@ethersproject/bignumber'
 import { createAction } from '@reduxjs/toolkit'
 
 export interface SerializedToken {
@@ -20,7 +21,7 @@ export const updateUserSingleHopOnly = createAction<{ userSingleHopOnly: boolean
 export const updateUserSlippageTolerance = createAction<{ userSlippageTolerance: number }>(
   'user/updateUserSlippageTolerance'
 )
-export const updateUserDeadline = createAction<{ userDeadline: number }>('user/updateUserDeadline')
+export const updateUserDeadline = createAction<{ userDeadline: BigNumber }>('user/updateUserDeadline')
 export const addSerializedToken = createAction<{ serializedToken: SerializedToken }>('user/addSerializedToken')
 export const removeSerializedToken = createAction<{ chainId: number; address: string }>('user/removeSerializedToken')
 export const addSerializedPair = createAction<{ serializedPair: SerializedPair }>('user/addSerializedPair')

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from '@ethersproject/bignumber'
 import { createAction } from '@reduxjs/toolkit'
 
 export interface SerializedToken {
@@ -21,7 +20,7 @@ export const updateUserSingleHopOnly = createAction<{ userSingleHopOnly: boolean
 export const updateUserSlippageTolerance = createAction<{ userSlippageTolerance: number }>(
   'user/updateUserSlippageTolerance'
 )
-export const updateUserDeadline = createAction<{ userDeadline: BigNumber }>('user/updateUserDeadline')
+export const updateUserDeadline = createAction<{ userDeadline: string }>('user/updateUserDeadline')
 export const addSerializedToken = createAction<{ serializedToken: SerializedToken }>('user/addSerializedToken')
 export const removeSerializedToken = createAction<{ chainId: number; address: string }>('user/removeSerializedToken')
 export const addSerializedPair = createAction<{ serializedPair: SerializedPair }>('user/addSerializedPair')

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -1,4 +1,3 @@
-import { BigNumber } from '@ethersproject/bignumber'
 import { ChainId, Pair, Token } from '@uniswap/sdk'
 import flatMap from 'lodash.flatmap'
 import { useCallback, useMemo } from 'react'
@@ -116,14 +115,14 @@ export function useUserSlippageTolerance(): [number, (slippage: number) => void]
   return [userSlippageTolerance, setUserSlippageTolerance]
 }
 
-export function useUserTransactionTTL(): [BigNumber, (slippage: BigNumber) => void] {
+export function useUserTransactionTTL(): [string, (slippage: string) => void] {
   const dispatch = useDispatch<AppDispatch>()
   const userDeadline = useSelector<AppState, AppState['user']['userDeadline']>(state => {
     return state.user.userDeadline
   })
 
   const setUserDeadline = useCallback(
-    (userDeadline: BigNumber) => {
+    (userDeadline: string) => {
       dispatch(updateUserDeadline({ userDeadline }))
     },
     [dispatch]

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -1,3 +1,4 @@
+import { BigNumber } from '@ethersproject/bignumber'
 import { ChainId, Pair, Token } from '@uniswap/sdk'
 import flatMap from 'lodash.flatmap'
 import { useCallback, useMemo } from 'react'
@@ -115,14 +116,14 @@ export function useUserSlippageTolerance(): [number, (slippage: number) => void]
   return [userSlippageTolerance, setUserSlippageTolerance]
 }
 
-export function useUserTransactionTTL(): [number, (slippage: number) => void] {
+export function useUserTransactionTTL(): [BigNumber, (slippage: BigNumber) => void] {
   const dispatch = useDispatch<AppDispatch>()
   const userDeadline = useSelector<AppState, AppState['user']['userDeadline']>(state => {
     return state.user.userDeadline
   })
 
   const setUserDeadline = useCallback(
-    (userDeadline: number) => {
+    (userDeadline: BigNumber) => {
       dispatch(updateUserDeadline({ userDeadline }))
     },
     [dispatch]

--- a/src/state/user/reducer.test.ts
+++ b/src/state/user/reducer.test.ts
@@ -26,7 +26,7 @@ describe('swap reducer', () => {
         userSlippageTolerance: undefined
       } as any)
       store.dispatch(updateVersion())
-      expect(store.getState().userDeadline).toEqual(DEFAULT_DEADLINE_FROM_NOW)
+      expect(store.getState().userDeadline.toNumber()).toEqual(DEFAULT_DEADLINE_FROM_NOW)
       expect(store.getState().userSlippageTolerance).toEqual(INITIAL_ALLOWED_SLIPPAGE)
     })
   })

--- a/src/state/user/reducer.test.ts
+++ b/src/state/user/reducer.test.ts
@@ -26,7 +26,7 @@ describe('swap reducer', () => {
         userSlippageTolerance: undefined
       } as any)
       store.dispatch(updateVersion())
-      expect(store.getState().userDeadline.toNumber()).toEqual(DEFAULT_DEADLINE_FROM_NOW)
+      expect(store.getState().userDeadline).toEqual(DEFAULT_DEADLINE_FROM_NOW.toString())
       expect(store.getState().userSlippageTolerance).toEqual(INITIAL_ALLOWED_SLIPPAGE)
     })
   })

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -1,5 +1,6 @@
 import { INITIAL_ALLOWED_SLIPPAGE, DEFAULT_DEADLINE_FROM_NOW } from '../../constants'
 import { createReducer } from '@reduxjs/toolkit'
+import { BigNumber } from '@ethersproject/bignumber'
 import { updateVersion } from '../global/actions'
 import {
   addSerializedPair,
@@ -34,7 +35,7 @@ export interface UserState {
   userSlippageTolerance: number
 
   // deadline set by user in minutes, used in all txns
-  userDeadline: number
+  userDeadline: BigNumber
 
   tokens: {
     [chainId: number]: {
@@ -63,7 +64,7 @@ export const initialState: UserState = {
   userExpertMode: false,
   userSingleHopOnly: false,
   userSlippageTolerance: INITIAL_ALLOWED_SLIPPAGE,
-  userDeadline: DEFAULT_DEADLINE_FROM_NOW,
+  userDeadline: BigNumber.from(DEFAULT_DEADLINE_FROM_NOW),
   tokens: {},
   pairs: {},
   timestamp: currentTimestamp(),
@@ -82,7 +83,7 @@ export default createReducer(initialState, builder =>
       // deadline isnt being tracked in local storage, reset to default
       // noinspection SuspiciousTypeOfGuard
       if (typeof state.userDeadline !== 'number') {
-        state.userDeadline = DEFAULT_DEADLINE_FROM_NOW
+        state.userDeadline = BigNumber.from(DEFAULT_DEADLINE_FROM_NOW)
       }
 
       state.lastUpdateVersionTimestamp = currentTimestamp()

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -1,6 +1,5 @@
 import { INITIAL_ALLOWED_SLIPPAGE, DEFAULT_DEADLINE_FROM_NOW } from '../../constants'
 import { createReducer } from '@reduxjs/toolkit'
-import { BigNumber } from '@ethersproject/bignumber'
 import { updateVersion } from '../global/actions'
 import {
   addSerializedPair,
@@ -35,7 +34,7 @@ export interface UserState {
   userSlippageTolerance: number
 
   // deadline set by user in minutes, used in all txns
-  userDeadline: BigNumber
+  userDeadline: string
 
   tokens: {
     [chainId: number]: {
@@ -64,7 +63,7 @@ export const initialState: UserState = {
   userExpertMode: false,
   userSingleHopOnly: false,
   userSlippageTolerance: INITIAL_ALLOWED_SLIPPAGE,
-  userDeadline: BigNumber.from(DEFAULT_DEADLINE_FROM_NOW),
+  userDeadline: DEFAULT_DEADLINE_FROM_NOW.toString(),
   tokens: {},
   pairs: {},
   timestamp: currentTimestamp(),
@@ -83,7 +82,7 @@ export default createReducer(initialState, builder =>
       // deadline isnt being tracked in local storage, reset to default
       // noinspection SuspiciousTypeOfGuard
       if (typeof state.userDeadline !== 'number') {
-        state.userDeadline = BigNumber.from(DEFAULT_DEADLINE_FROM_NOW)
+        state.userDeadline = DEFAULT_DEADLINE_FROM_NOW.toString()
       }
 
       state.lastUpdateVersionTimestamp = currentTimestamp()


### PR DESCRIPTION
This PR switches `userDeadline` to `BigNumber` representation to fix Uniswap/uniswap-interface#1313.

Users can now enter an arbitrarily high number for transaction deadline without the interface crashing. All other UI behaviors are unaltered.