### PR TITLE
Feature Request: ETH2x-FLI to ETH2X pair routing

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -39,6 +39,7 @@ export const TRIBE = new Token(ChainId.MAINNET, '0xc7283b66Eb1EB5FB86327f08e1B58
 export const FRAX = new Token(ChainId.MAINNET, '0x853d955aCEf822Db058eb8505911ED77F175b99e', 18, 'FRAX', 'Frax')
 export const FXS = new Token(ChainId.MAINNET, '0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0', 18, 'FXS', 'Frax Share')
 export const renBTC = new Token(ChainId.MAINNET, '0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D', 8, 'renBTC', 'renBTC')
+export const ETH2X-FLI = new Token(ChainId.MAINNET,'0xAa6E8127831c9DE45ae56bB1b0d4D4Da6e5665BD', 18, 'ETH2X-FLI','ETH 2x Flexible Leverage Index')
 
 // Block time here is slightly higher (~1s) than average in order to avoid ongoing proposals past the displayed time
 export const AVERAGE_BLOCK_TIME_IN_SECS = 13
@@ -86,6 +87,7 @@ export const ADDITIONAL_BASES: { [chainId in ChainId]?: { [tokenAddress: string]
   [ChainId.MAINNET]: {
     '0xA948E86885e12Fb09AfEF8C52142EBDbDf73cD18': [UNI[ChainId.MAINNET]],
     '0x561a4717537ff4AF5c687328c0f7E90a319705C0': [UNI[ChainId.MAINNET]],
+    '0xf16e4d813f4dcfde4c5b44f305c908742de84ef0': [ETH2X-FLI],
     [FEI.address]: [TRIBE],
     [TRIBE.address]: [FEI],
     [FRAX.address]: [FXS],

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -39,7 +39,7 @@ export const TRIBE = new Token(ChainId.MAINNET, '0xc7283b66Eb1EB5FB86327f08e1B58
 export const FRAX = new Token(ChainId.MAINNET, '0x853d955aCEf822Db058eb8505911ED77F175b99e', 18, 'FRAX', 'Frax')
 export const FXS = new Token(ChainId.MAINNET, '0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0', 18, 'FXS', 'Frax Share')
 export const renBTC = new Token(ChainId.MAINNET, '0xEB4C2781e4ebA804CE9a9803C67d0893436bB27D', 8, 'renBTC', 'renBTC')
-export const ETH2X-FLI = new Token(ChainId.MAINNET,'0xAa6E8127831c9DE45ae56bB1b0d4D4Da6e5665BD', 18, 'ETH2X-FLI','ETH 2x Flexible Leverage Index')
+export const ETH2X_FLI = new Token(ChainId.MAINNET,'0xAa6E8127831c9DE45ae56bB1b0d4D4Da6e5665BD', 18, 'ETH2X-FLI','ETH 2x Flexible Leverage Index')
 
 // Block time here is slightly higher (~1s) than average in order to avoid ongoing proposals past the displayed time
 export const AVERAGE_BLOCK_TIME_IN_SECS = 13
@@ -87,7 +87,7 @@ export const ADDITIONAL_BASES: { [chainId in ChainId]?: { [tokenAddress: string]
   [ChainId.MAINNET]: {
     '0xA948E86885e12Fb09AfEF8C52142EBDbDf73cD18': [UNI[ChainId.MAINNET]],
     '0x561a4717537ff4AF5c687328c0f7E90a319705C0': [UNI[ChainId.MAINNET]],
-    '0xf16e4d813f4dcfde4c5b44f305c908742de84ef0': [ETH2X-FLI],
+    '0xf16e4d813f4dcfde4c5b44f305c908742de84ef0': [ETH2X_FLI],
     [FEI.address]: [TRIBE],
     [TRIBE.address]: [FEI],
     [FRAX.address]: [FXS],


### PR DESCRIPTION
This allows direct routing between leveraged tokenset to tokenset pair particularly between ETH2x-FLI and ETH2X pair.