### PR TITLE
Fix NFT SVG performance issue in browser

### DIFF
--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -194,8 +194,7 @@ function getRatio(lower: Price, current: Price, upper: Price) {
 }
 
 function NFT({ image }: { image: string }) {
-  // Initialize to true to mount the <img> to set the width/height.
-  const [animate, setAnimate] = useState(true)
+  const [animate, setAnimate] = useState(false)
   const animatedStyles = useSpring({ opacity: animate ? 1 : 0 })
   const staticStyles = useSpring({ opacity: animate ? 0 : 1 })
 

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -180,6 +180,7 @@ function getRatio(lower: Price, current: Price, upper: Price) {
 }
 
 function NFT({ image }: { image: string }) {
+  // Initialize to true to mount the <img> to set the width/height.
   const [animate, setAnimate] = useState(true)
 
   const canvasRef = useRef<HTMLCanvasElement>()
@@ -190,9 +191,23 @@ function NFT({ image }: { image: string }) {
       return
     }
 
-    canvasRef.current.width = src.width
-    canvasRef.current.height = src.height
-    canvasRef.current.getContext('2d')?.drawImage(src, 0, 0, src.width, src.height)
+    const { current: canvas } = canvasRef
+    const context = canvas.getContext('2d')
+    if (!context) {
+      return
+    }
+
+    const { width, height } = src
+
+    // Ensure crispness at high DPIs
+    canvas.width = width * devicePixelRatio
+    canvas.height = height * devicePixelRatio
+    canvas.style.width = width + 'px'
+    canvas.style.height = height + 'px'
+    context.scale(devicePixelRatio, devicePixelRatio)
+
+    context.clearRect(0, 0, width, height)
+    context.drawImage(src, 0, 0, width, height)
   }
 
   const mouseLeave = () => {

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { SyntheticEvent, useCallback, useMemo, useRef, useState } from 'react'
 import { NonfungiblePositionManager, Pool, Position } from '@uniswap/v3-sdk'
 
 import { PoolState, usePool } from 'hooks/usePools'

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -210,7 +210,7 @@ function NFT({ image, height: targetHeight }: { image: string; height: number })
 
     let { width, height } = src
 
-    // src may be hidden and not have the target dimensions.
+    // src may be hidden and not have the target dimensions
     const ratio = width / height
     height = targetHeight
     width = Math.round(ratio * targetHeight)
@@ -226,20 +226,14 @@ function NFT({ image, height: targetHeight }: { image: string; height: number })
     context.drawImage(src, 0, 0, width, height)
   }
 
-  const onMouseLeave = () => {
-    if (!imageRef.current) return
-    getSnapshot(imageRef.current)
-    setAnimate(false)
-  }
-
   const onLoad = (e: SyntheticEvent<HTMLImageElement>) => {
     getSnapshot(e.target as HTMLImageElement)
   }
 
   return (
-    <NFTGrid onMouseEnter={() => setAnimate(true)} onMouseLeave={onMouseLeave}>
+    <NFTGrid onMouseEnter={() => setAnimate(true)} onMouseLeave={() => setAnimate(false)}>
+      <NFTCanvas ref={canvasRef as any} style={{ visibility: animate ? 'hidden' : 'visible' }} />
       <NFTImage src={image} hidden={!animate} onLoad={onLoad} ref={imageRef as any} />
-      <NFTCanvas ref={canvasRef as any} hidden={animate} />
     </NFTGrid>
   )
 }

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -210,10 +210,12 @@ function NFT({ image, height: targetHeight }: { image: string; height: number })
 
     let { width, height } = src
 
-    // resize to target height
+    // src may be hidden and not have the target dimensions.
     const ratio = width / height
     height = targetHeight
     width = Math.round(ratio * targetHeight)
+
+    debugger
 
     // Ensure crispness at high DPIs
     canvas.width = width * devicePixelRatio
@@ -236,14 +238,10 @@ function NFT({ image, height: targetHeight }: { image: string; height: number })
     getSnapshot(e.target as HTMLImageElement)
   }
 
-  // permanently mounted to allow snapshots onto canvas
-  // `hidden`: won't cause performance issues with layout changes
-  const hiddenImg = <img src={image} hidden onLoad={onLoad} ref={imageRef as any} />
-
   return (
     <NFTGrid onMouseEnter={() => setAnimate(true)} onMouseLeave={() => setAnimate(false)}>
-      {hiddenImg}
-      {animate ? <NFTImage src={image} /> : <NFTCanvas ref={canvasRef as any} />}
+      <NFTImage src={image} hidden={!animate} onLoad={onLoad} ref={imageRef as any} />
+      <NFTCanvas ref={canvasRef as any} hidden={animate} />
     </NFTGrid>
   )
 }

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -139,6 +139,7 @@ const NFTCanvas = styled.canvas`
 const NFTImage = styled.img`
   grid-area: overlap;
   height: 400px;
+  /* Ensures SVG appears on top of canvas. */
   z-index: 1;
 `
 

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -215,8 +215,6 @@ function NFT({ image, height: targetHeight }: { image: string; height: number })
     height = targetHeight
     width = Math.round(ratio * targetHeight)
 
-    debugger
-
     // Ensure crispness at high DPIs
     canvas.width = width * devicePixelRatio
     canvas.height = height * devicePixelRatio

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -226,18 +226,18 @@ function NFT({ image, height: targetHeight }: { image: string; height: number })
     context.drawImage(src, 0, 0, width, height)
   }
 
-  useEffect(() => {
+  const onMouseLeave = () => {
     if (!imageRef.current) return
-    if (animate) return
     getSnapshot(imageRef.current)
-  })
+    setAnimate(false)
+  }
 
   const onLoad = (e: SyntheticEvent<HTMLImageElement>) => {
     getSnapshot(e.target as HTMLImageElement)
   }
 
   return (
-    <NFTGrid onMouseEnter={() => setAnimate(true)} onMouseLeave={() => setAnimate(false)}>
+    <NFTGrid onMouseEnter={() => setAnimate(true)} onMouseLeave={onMouseLeave}>
       <NFTImage src={image} hidden={!animate} onLoad={onLoad} ref={imageRef as any} />
       <NFTCanvas ref={canvasRef as any} hidden={animate} />
     </NFTGrid>

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { SyntheticEvent, useCallback, useMemo, useRef, useState } from 'react'
 import { NonfungiblePositionManager, Pool, Position } from '@uniswap/v3-sdk'
 
 import { PoolState, usePool } from 'hooks/usePools'
@@ -177,6 +177,43 @@ function getRatio(lower: Price, current: Price, upper: Price) {
   } catch {
     return undefined
   }
+}
+
+function NFT({ image }: { image: string }) {
+  const [animate, setAnimate] = useState(true)
+
+  const canvasRef = useRef<HTMLCanvasElement>()
+  const imageRef = useRef<HTMLImageElement>()
+
+  const getSnapshot = (src: HTMLImageElement) => {
+    if (!canvasRef.current) {
+      return
+    }
+
+    canvasRef.current.width = src.width
+    canvasRef.current.height = src.height
+    canvasRef.current.getContext('2d')?.drawImage(src, 0, 0, src.width, src.height)
+  }
+
+  const mouseLeave = () => {
+    if (!imageRef.current) {
+      return
+    }
+    getSnapshot(imageRef.current)
+    setAnimate(false)
+  }
+
+  const onLoad = (e: SyntheticEvent<HTMLImageElement>) => {
+    getSnapshot(e.target as HTMLImageElement)
+    setAnimate(false)
+  }
+
+  return (
+    <div onMouseEnter={() => setAnimate(true)} onMouseLeave={mouseLeave}>
+      <canvas ref={canvasRef as any} hidden={animate} />
+      <img height="400px" src={image} onLoad={onLoad} ref={imageRef as any} hidden={!animate} />
+    </div>
+  )
 }
 
 export function PositionPage({
@@ -453,7 +490,7 @@ export function PositionPage({
               }}
             >
               <div style={{ marginRight: 12 }}>
-                <img height="400px" src={metadata.result.image} />
+                <NFT image={metadata.result.image} />
               </div>
               {typeof chainId === 'number' && owner && !ownsNFT ? (
                 <ExternalLink href={getEtherscanLink(chainId, owner, 'address')}>Owner</ExternalLink>

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -139,6 +139,7 @@ const NFTCanvas = styled.canvas`
 const NFTImage = styled.img`
   grid-area: overlap;
   height: 400px;
+  z-index: 1;
 `
 
 function CurrentPriceCard({
@@ -232,7 +233,7 @@ function NFT({ image, height: targetHeight }: { image: string; height: number })
 
   return (
     <NFTGrid onMouseEnter={() => setAnimate(true)} onMouseLeave={() => setAnimate(false)}>
-      <NFTCanvas ref={canvasRef as any} style={{ visibility: animate ? 'hidden' : 'visible' }} />
+      <NFTCanvas ref={canvasRef as any} />
       <NFTImage src={image} hidden={!animate} onLoad={onLoad} ref={imageRef as any} />
     </NFTGrid>
   )

--- a/src/pages/Pool/PositionPage.tsx
+++ b/src/pages/Pool/PositionPage.tsx
@@ -38,6 +38,7 @@ import { useSingleCallResult } from 'state/multicall/hooks'
 import RangeBadge from '../../components/Badge/RangeBadge'
 import useUSDCPrice from 'hooks/useUSDCPrice'
 import Loader from 'components/Loader'
+import { animated, useSpring } from 'react-spring'
 
 const PageWrapper = styled.div`
   min-width: 800px;
@@ -126,6 +127,19 @@ const ResponsiveButtonPrimary = styled(ButtonPrimary)`
   `};
 `
 
+const NFTGrid = styled.div`
+  display: grid;
+  grid-template: 'overlap';
+`
+
+const NFTCanvas = styled(animated.canvas)`
+  grid-area: overlap;
+`
+
+const NFTImage = styled(animated.img)`
+  grid-area: overlap;
+`
+
 function CurrentPriceCard({
   inverted,
   pool,
@@ -182,6 +196,8 @@ function getRatio(lower: Price, current: Price, upper: Price) {
 function NFT({ image }: { image: string }) {
   // Initialize to true to mount the <img> to set the width/height.
   const [animate, setAnimate] = useState(true)
+  const animatedStyles = useSpring({ opacity: animate ? 1 : 0 })
+  const staticStyles = useSpring({ opacity: animate ? 0 : 1 })
 
   const canvasRef = useRef<HTMLCanvasElement>()
   const imageRef = useRef<HTMLImageElement>()
@@ -224,10 +240,10 @@ function NFT({ image }: { image: string }) {
   }
 
   return (
-    <div onMouseEnter={() => setAnimate(true)} onMouseLeave={mouseLeave}>
-      <canvas ref={canvasRef as any} hidden={animate} />
-      <img height="400px" src={image} onLoad={onLoad} ref={imageRef as any} hidden={!animate} />
-    </div>
+    <NFTGrid onMouseEnter={() => setAnimate(true)} onMouseLeave={mouseLeave}>
+      <NFTCanvas ref={canvasRef as any} style={staticStyles} />
+      <NFTImage src={image} onLoad={onLoad} ref={imageRef as any} style={animatedStyles} />
+    </NFTGrid>
   )
 }
 


### PR DESCRIPTION
Disabled NFT SVG animation, only enabled on hover

The animated SVG was causing serious performance issues because of the many layout changes. We should consider changes the SVG definition, but for now, this PR disables animations until hover.

The solution is to snapshot the SVG state onto a static canvas and show that canvas. On hover, show the actual image.

Other approaches considered:
 - SVGSVGElement.pauseAnimations(): unfortunately, the SVG is received as a data:img payload, and inserting it on the page would not be safe
 - Stopping CSS animations: CSS animations are not used in the SVG

Testing:
 - Performance was monitored in Activity Monitor
 - Low CPU usage, spike on hover, returns to low usage on leave
 
✅ macOS: Chrome, Firefox, Safari
✅ Android:  Chrome (animates on tap, stops on tap outside)
 
- only animate NFT SVG on hover by using a canvas
- handle high dpis
- animation transition between canvas and img
- set start state to not animated
- removed animations that were causing issues on Firefox

fixes #1466
