### PR TITLE
fix header elements overlapping at around before upToMedium breakpoint

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -32,7 +32,7 @@ import UniBalanceContent from './UniBalanceContent'
 
 const HeaderFrame = styled.div<{ showBackground: boolean }>`
   display: grid;
-  grid-template-columns: 120px 1fr 120px;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
Keeps the HeaderLinks centered unless the right section needs to grow

![image](https://user-images.githubusercontent.com/1284993/118295758-36b1e400-b4aa-11eb-9074-d2c255aeb217.png)

     ⬇️

![image](https://user-images.githubusercontent.com/1284993/118295912-66f98280-b4aa-11eb-8f70-a69a0c82fc18.png)
