### PR TITLE
Leverage Trade api for USDC price with v2 & v3 support

### DIFF
--- a/src/hooks/useUSDCPrice.ts
+++ b/src/hooks/useUSDCPrice.ts
@@ -1,81 +1,34 @@
-import { ChainId, Currency, CurrencyAmount, currencyEquals, Price, Token, WETH9 } from '@uniswap/sdk-core'
-import JSBI from 'jsbi'
+import { Currency, CurrencyAmount, Price, Token } from '@uniswap/sdk-core'
 import { useMemo } from 'react'
 import { USDC } from '../constants'
-import { PairState, useV2Pairs } from './useV2Pairs'
-import { useActiveWeb3React } from '../hooks'
-import { wrappedCurrency } from '../utils/wrappedCurrency'
+import { useV2TradeExactOut } from './useV2Trade'
+import { tryParseAmount } from 'state/swap/hooks'
+import { useBestV3TradeExactOut, V3TradeState } from './useBestV3Trade'
+
+// USDC amount used when calculating spot price for a given currency.
+// The amount is large enouhg to filter low liquidity pairs.
+const usdcCurrencyAmount = tryParseAmount('10000', USDC)
 
 /**
  * Returns the price in USDC of the input currency
  * @param currency currency to compute the USDC price of
  */
 export default function useUSDCPrice(currency?: Currency): Price<Currency, Token> | undefined {
-  const { chainId } = useActiveWeb3React()
-  const wrapped = wrappedCurrency(currency, chainId)
-  const weth = WETH9[chainId as ChainId]
+  const v2USDCTrade = useV2TradeExactOut(currency, usdcCurrencyAmount)
+  const v3USDCTrade = useBestV3TradeExactOut(currency, usdcCurrencyAmount)
 
-  const tokenPairs: [Currency | undefined, Currency | undefined][] = useMemo(
-    () => [
-      [chainId && wrapped && currencyEquals(weth, wrapped) ? undefined : currency, chainId ? weth : undefined],
-      [wrapped?.equals(USDC) ? undefined : wrapped, chainId === ChainId.MAINNET ? USDC : undefined],
-      [chainId ? weth : undefined, chainId === ChainId.MAINNET ? USDC : undefined],
-    ],
-    [chainId, currency, weth, wrapped]
-  )
-  const [[ethPairState, ethPair], [usdcPairState, usdcPair], [usdcEthPairState, usdcEthPair]] = useV2Pairs(tokenPairs)
+  if (!currency) return undefined
 
-  return useMemo(() => {
-    if (!currency || !wrapped || !chainId) {
-      return undefined
-    }
-    // return some fake price data for non-mainnet
-    if (chainId !== ChainId.MAINNET) {
-      const fakeUSDC = new Token(chainId, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 6, 'fUSDC', 'Fake USDC')
-      return new Price(
-        currency,
-        fakeUSDC,
-        10 ** Math.max(0, currency.decimals - 6),
-        15 * 10 ** Math.max(6 - currency.decimals, 0)
-      )
-    }
+  // Use v2 price if available, v3 as fallback.
+  if (v2USDCTrade) {
+    const { numerator, denominator } = v2USDCTrade.route.midPrice
+    return new Price(currency, USDC, denominator, numerator)
+  } else if (v3USDCTrade.state === V3TradeState.VALID && v3USDCTrade.trade) {
+    const { numerator, denominator } = v3USDCTrade.trade.route.midPrice
+    return new Price(currency, USDC, denominator, numerator)
+  }
 
-    // handle weth/eth
-    if (wrapped.equals(weth)) {
-      if (usdcPair) {
-        const price = usdcPair.priceOf(weth)
-        return new Price(currency, USDC, price.denominator, price.numerator)
-      } else {
-        return undefined
-      }
-    }
-    // handle usdc
-    if (wrapped.equals(USDC)) {
-      return new Price(USDC, USDC, '1', '1')
-    }
-
-    const ethPairETHAmount = ethPair?.reserveOf(weth)
-    const ethPairETHUSDCValue: JSBI =
-      ethPairETHAmount?.greaterThan(0) && usdcEthPair?.reserveOf(weth)?.greaterThan(0)
-        ? usdcEthPair.priceOf(weth).quote(ethPairETHAmount).quotient
-        : JSBI.BigInt(0)
-
-    // all other tokens
-    // first try the usdc pair
-    if (usdcPairState === PairState.EXISTS && usdcPair && usdcPair.reserveOf(USDC).greaterThan(ethPairETHUSDCValue)) {
-      const price = usdcPair.priceOf(wrapped)
-      return new Price(currency, USDC, price.denominator, price.numerator)
-    }
-    if (ethPairState === PairState.EXISTS && ethPair && usdcEthPairState === PairState.EXISTS && usdcEthPair) {
-      if (usdcEthPair.reserveOf(USDC).greaterThan('0') && ethPair.reserveOf(weth).greaterThan('0')) {
-        const ethUsdcPrice = usdcEthPair.priceOf(USDC)
-        const currencyEthPrice = ethPair.priceOf(weth)
-        const usdcPrice = ethUsdcPrice.multiply(currencyEthPrice).invert()
-        return new Price(currency, USDC, usdcPrice.denominator, usdcPrice.numerator)
-      }
-    }
-    return undefined
-  }, [chainId, currency, ethPair, ethPairState, usdcEthPair, usdcEthPairState, usdcPair, usdcPairState, weth, wrapped])
+  return undefined
 }
 
 export function useUSDCValue(currencyAmount: CurrencyAmount<Currency> | undefined | null) {


### PR DESCRIPTION
- Leverage Trade API tradeExactOut(USDC) rather than custom impl. for eth-usdc-currency pairs
- Also adds support for v3 prices as fallback when v2 prices not available (relevant for pairs that do not have (sufficient) liquidity in v2)

fixes #1552
