### PR TITLE
fix: update tick parsing to handle min/max prices

### DIFF
--- a/src/state/mint/v3/utils.ts
+++ b/src/state/mint/v3/utils.ts
@@ -1,6 +1,14 @@
-import { priceToClosestTick, nearestUsableTick, FeeAmount, TICK_SPACINGS } from '@uniswap/v3-sdk/dist/'
+import {
+  priceToClosestTick,
+  nearestUsableTick,
+  FeeAmount,
+  TICK_SPACINGS,
+  encodeSqrtRatioX96,
+  TickMath,
+} from '@uniswap/v3-sdk/dist/'
 import { Price, Token } from '@uniswap/sdk-core'
 import { tryParseAmount } from 'state/swap/hooks'
+import JSBI from 'jsbi'
 
 export function tryParseTick(
   baseToken?: Token,
@@ -12,8 +20,8 @@ export function tryParseTick(
     return undefined
   }
 
+  // base token fixed at 1 unit, quote token amount based on typed input
   const amount = tryParseAmount(value, quoteToken)
-
   const amountOne = tryParseAmount('1', baseToken)
 
   if (!amount || !amountOne) return undefined
@@ -21,8 +29,19 @@ export function tryParseTick(
   // parse the typed value into a price
   const price = new Price(baseToken, quoteToken, amountOne.quotient, amount.quotient)
 
-  // this function is agnostic to the base, will always return the correct tick
-  const tick = priceToClosestTick(price)
+  let tick: number
+
+  // check price is within min/max bounds, if outside return min/max
+  const sqrtRatioX96 = encodeSqrtRatioX96(price.numerator, price.denominator)
+
+  if (JSBI.greaterThanOrEqual(sqrtRatioX96, TickMath.MAX_SQRT_RATIO)) {
+    tick = TickMath.MAX_TICK - TICK_SPACINGS[3000]
+  } else if (JSBI.lessThanOrEqual(sqrtRatioX96, TickMath.MIN_SQRT_RATIO)) {
+    tick = TickMath.MIN_TICK
+  } else {
+    // this function is agnostic to the base, will always return the correct tick
+    tick = priceToClosestTick(price)
+  }
 
   return nearestUsableTick(tick, TICK_SPACINGS[feeAmount])
 }

--- a/src/state/mint/v3/utils.ts
+++ b/src/state/mint/v3/utils.ts
@@ -35,7 +35,7 @@ export function tryParseTick(
   const sqrtRatioX96 = encodeSqrtRatioX96(price.numerator, price.denominator)
 
   if (JSBI.greaterThanOrEqual(sqrtRatioX96, TickMath.MAX_SQRT_RATIO)) {
-    tick = TickMath.MAX_TICK - TICK_SPACINGS[3000]
+    tick = TickMath.MAX_TICK
   } else if (JSBI.lessThanOrEqual(sqrtRatioX96, TickMath.MIN_SQRT_RATIO)) {
     tick = TickMath.MIN_TICK
   } else {


### PR DESCRIPTION
- right now if user types in price above/below the min/max ratio for a pool the price -> conversion logic crashes
- to handle this, check for this case and return min/max values instead when parsing the input
- fixes #1571 