### PR TITLE
fix: division by 0 error when both reserves are 0

### DIFF
--- a/src/hooks/useV2Pairs.ts
+++ b/src/hooks/useV2Pairs.ts
@@ -48,6 +48,7 @@ export function useV2Pairs(currencies: [Currency | undefined, Currency | undefin
       if (!tokenA || !tokenB || tokenA.equals(tokenB)) return [PairState.INVALID, null]
       if (!reserves) return [PairState.NOT_EXISTS, null]
       const { reserve0, reserve1 } = reserves
+      if (reserve0.isZero() && reserve1.isZero()) return [PairState.NOT_EXISTS, null]
       const [token0, token1] = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA]
       return [
         PairState.EXISTS,

--- a/src/hooks/useV2Pairs.ts
+++ b/src/hooks/useV2Pairs.ts
@@ -48,7 +48,6 @@ export function useV2Pairs(currencies: [Currency | undefined, Currency | undefin
       if (!tokenA || !tokenB || tokenA.equals(tokenB)) return [PairState.INVALID, null]
       if (!reserves) return [PairState.NOT_EXISTS, null]
       const { reserve0, reserve1 } = reserves
-      if (reserve0.isZero() && reserve1.isZero()) return [PairState.NOT_EXISTS, null]
       const [token0, token1] = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA]
       return [
         PairState.EXISTS,

--- a/src/state/mint/hooks.ts
+++ b/src/state/mint/hooks.ts
@@ -83,7 +83,14 @@ export function useDerivedMintInfo(
   const totalSupply = useTotalSupply(pair?.liquidityToken)
 
   const noLiquidity: boolean =
-    pairState === PairState.NOT_EXISTS || Boolean(totalSupply && JSBI.equal(totalSupply.quotient, ZERO))
+    pairState === PairState.NOT_EXISTS ||
+    Boolean(totalSupply && JSBI.equal(totalSupply.quotient, ZERO)) ||
+    Boolean(
+      pairState === PairState.EXISTS &&
+        pair &&
+        JSBI.equal(pair.reserve0.quotient, ZERO) &&
+        JSBI.equal(pair.reserve1.quotient, ZERO)
+    )
 
   // balances
   const balances = useCurrencyBalances(account ?? undefined, [


### PR DESCRIPTION
fixes #1583

IUniswapV2Pair.getReserves() returns a 'valid' pair for some tokens (see #1583). However, the reserves are both set to 0 whhich leads to a division by zero down the line.

Fix suggested is to consider a pair where both reserves are 0 as NOT_EXISTS.
