### PR TITLE
fix: correct etherscan URL when using an ENS name

### DIFF
--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -354,7 +354,7 @@ export default function AccountDetails({
                           <AddressLink
                             hasENS={!!ENSName}
                             isENS={true}
-                            href={getExplorerLink(chainId, ENSName, ExplorerDataType.ADDRESS)}
+                            href={getExplorerLink(chainId, account, ExplorerDataType.ADDRESS)}
                           >
                             <LinkIcon size={16} />
                             <span style={{ marginLeft: '4px' }}>View on Etherscan</span>


### PR DESCRIPTION
Fixes #1731

As proposed in #1731, an option would be to point the URL to the ENS lookup instead (example: https://etherscan.io/enslookup-search?search=erik.bjareholt.eth). But that would require an addition to [`getExplorerLink`](https://github.com/Uniswap/uniswap-interface/blob/7f1def300d3d036555bcc2e2b2368b9aeb373b8f/src/utils/getExplorerLink.ts#L22).