### PR TITLE
fix: add padding to price outside of range

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -198,7 +198,7 @@ export default function CurrencyInputPanel({
         <FixedContainer>
           <AutoColumn gap="sm" justify="center">
             <Lock />
-            <TYPE.label fontSize="12px" textAlign="center">
+            <TYPE.label fontSize="12px" textAlign="center" padding="0 12px">
               <Trans>The market price is outside your specified price range. Single-asset deposit only.</Trans>
             </TYPE.label>
           </AutoColumn>


### PR DESCRIPTION
## Description

The "outside of your specified range" text in the add liquidity UI needs padding. I've added a horizontal padding of `12px` so the text isn't squished on the sides.

This PR addresses #1693.

## Screenshots

### Before:
<img width="436" alt="Screen Shot 2021-05-29 at 11 54 01 PM" src="https://user-images.githubusercontent.com/1811365/120096065-39355000-c0de-11eb-9bc3-b39dea187d5e.png">

### After:
<img width="436" alt="Screen Shot 2021-05-29 at 11 54 27 PM" src="https://user-images.githubusercontent.com/1811365/120096069-3aff1380-c0de-11eb-8e31-f462953fe9ed.png">
