### PR TITLE
Fix @emotion/core deprecation error on npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "homepage": ".",
   "private": true,
   "devDependencies": {
-    "@emotion/core": "^11.0.0",
     "@ethersproject/experimental": "^5.2.0",
     "@lingui/cli": "^3.9.0",
     "@lingui/loader": "^3.9.0",


### PR DESCRIPTION
On a clean `npm install && npm start` I receive an error message about `@emotion/core` being deprecated and replaced with `@emotion/react`

From investigating it looks like storybook has it's own version of `@emotion` and you don't need to install it seperately.

`@storybook/theming` uses `@emotion/core@10.1.1` and the current `@emotion/core` in package.json is deprecated