### PR TITLE
perf: load inter-ui with 'font-display: block'

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,3 @@
-import 'inter-ui'
 import { Story } from '@storybook/react/types-6-0'
 import { createWeb3ReactRoot, Web3ReactProvider } from '@web3-react/core'
 import React from 'react'

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "react-window": "^1.8.5",
     "rebass": "^4.0.7",
     "redux-localstorage-simple": "^2.3.1",
+    "sass": "^1.34.0",
     "serve": "^11.3.2",
     "start-server-and-test": "^1.11.0",
     "styled-components": "^4.2.0",
@@ -153,6 +154,5 @@
       "last 1 safari version"
     ]
   },
-  "license": "GPL-3.0-or-later",
-  "dependencies": {}
+  "license": "GPL-3.0-or-later"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 import { createWeb3ReactRoot, Web3ReactProvider } from '@web3-react/core'
-import 'inter-ui'
 import React, { StrictMode } from 'react'
 import { isMobile } from 'react-device-detect'
 import ReactDOM from 'react-dom'

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -7,6 +7,7 @@ import styled, {
   ThemeProvider as StyledComponentsThemeProvider,
 } from 'styled-components'
 import { useIsDarkMode } from '../state/user/hooks'
+import './inter.scss'
 import { Colors } from './styled'
 
 export * from './components'
@@ -206,25 +207,15 @@ export const ThemedBackground = styled.div<{ backgroundColor?: string | undefine
 `
 
 export const FixedGlobalStyle = createGlobalStyle`
-html, input, textarea, button {
-  font-family: 'Inter', sans-serif;
-  font-display: fallback;
-}
-@supports (font-variation-settings: normal) {
-  html, input, textarea, button {
-    font-family: 'Inter var', sans-serif;
-  }
-}
-
 html,
 body {
   margin: 0;
   padding: 0;
 }
 
- a {
-   color: ${colors(false).blue1}; 
- }
+a {
+  color: ${colors(false).blue1}; 
+}
 
 * {
   box-sizing: border-box;
@@ -241,7 +232,6 @@ html {
   -moz-osx-font-smoothing: grayscale;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   font-feature-settings: 'ss01' on, 'ss02' on,  'cv01' on, 'cv03' on;
-  
 }
 `
 

--- a/src/theme/inter.scss
+++ b/src/theme/inter.scss
@@ -1,0 +1,18 @@
+@use "~inter-ui/default" with (
+  $inter-font-display: block,
+);
+@use "~inter-ui/variable" with (
+  $inter-font-display: block,
+);
+@include default.all;
+@include variable.all;
+
+html, input, textarea, button {
+  font-family: 'Inter', sans-serif;
+}
+
+@supports (font-variation-settings: normal) {
+  html, input, textarea, button {
+    font-family: 'Inter var', sans-serif;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6843,7 +6843,7 @@ checkpoint-store@^1.1.0:
   dependencies:
     functional-red-black-tree "^1.0.1"
 
-chokidar@3.5.1, chokidar@^3.4.1, chokidar@^3.4.2:
+chokidar@3.5.1, "chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.4.2:
   version "3.5.1"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
@@ -17085,6 +17085,13 @@ sass-loader@^10.0.5:
     neo-async "^2.6.2"
     schema-utils "^3.0.0"
     semver "^7.3.2"
+
+sass@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.34.0.tgz#e46d5932d8b0ecc4feb846d861f26a578f7f7172"
+  integrity sha512-rHEN0BscqjUYuomUEaqq3BMgsXqQfkcMVR7UhscsAVub0/spUrZGBMxQXFS2kfiDsPLZw5yuU9iJEFNC2x38Qw==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
 
 sax@>=0.6.0, sax@~1.2.4:
   version "1.2.4"


### PR DESCRIPTION
Loads Inter font family with `font-display: block`. Fixes #1730.

Loading fonts with `font-display: block` prevents fonts from swapping immediately after rendering ([spec]), which causes a flash of unstyled text (FOUT). The `block` usually lasts 3 seconds, so networks which load the font in over 3 seconds will still have a FOUT.

Removing FOUT on slower networks would require preloading the font, which is infeasible with hashed woff2 files. It requires copying the fonts to the public/ directory, which introduces an unnecessary amount of complexity and increased build time (see #1765, closes #1765).

[spec]: https://drafts.csswg.org/css-fonts-4/#font-display-desc