### PR TITLE
fix: <unk> in locales file

### DIFF
--- a/src/locales/ar-SA.po
+++ b/src/locales/ar-SA.po
@@ -1959,5 +1959,5 @@ msgstr "~$ <0/>"
 
 #: src/pages/Pool/PositionPage.tsx
 msgid "← Back to Pools Overview"
-msgstr "<unk> العودة إلى نظرة عامة للمتجمعات"
+msgstr "← العودة إلى نظرة عامة للمتجمعات"
 

--- a/src/locales/ja-JP.po
+++ b/src/locales/ja-JP.po
@@ -199,7 +199,7 @@ msgstr "請求可能なアドレスではありません"
 
 #: src/pages/Vote/VotePage.tsx
 msgid "Against"
-msgstr "<unk>"
+msgstr "反対"
 
 #: src/pages/MigrateV2/MigrateV2Pair.tsx
 msgid "Allow LP token migration"
@@ -823,7 +823,7 @@ msgstr "詳細情報"
 #: src/components/claim/ClaimModal.tsx
 #: src/pages/Pool/PositionPage.tsx
 msgid "Liquidity"
-msgstr "<unk>"
+msgstr "流動性"
 
 #: src/components/swap/AdvancedSwapDetails.tsx
 msgid "Liquidity Provider Fee"
@@ -1410,7 +1410,7 @@ msgstr "合計入金額"
 
 #: src/pages/Earn/Manage.tsx
 msgid "Total deposits"
-msgstr "合計<unk>"
+msgstr "合計入金額"
 
 #: src/components/Settings/index.tsx
 msgid "Transaction Settings"
@@ -1492,7 +1492,7 @@ msgstr "ユニスワップが利用可能: <0>{0}</0>"
 
 #: src/pages/Earn/index.tsx
 msgid "Uniswap liquidity mining"
-msgstr "流動性マイニングを<unk>"
+msgstr "流動性マイニングする"
 
 #: src/pages/MigrateV2/MigrateV2Pair.tsx
 msgid "Uniswap migration contract↗"

--- a/src/locales/ru-RU.po
+++ b/src/locales/ru-RU.po
@@ -1959,5 +1959,5 @@ msgstr "~$ <0/>"
 
 #: src/pages/Pool/PositionPage.tsx
 msgid "← Back to Pools Overview"
-msgstr "<unk> Назад к пулам"
+msgstr "← Назад к пулам"
 


### PR DESCRIPTION
Fixed <unk> in the files ja-Jp.po, ru-Ru.po, and ar-SA.po