### PR TITLE
fix: memoize extendedEther to unnecessary rerenders

### DIFF
--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -179,7 +179,8 @@ export function useCurrency(currencyId: string | undefined): Currency | null | u
   const { chainId } = useActiveWeb3React()
   const isETH = currencyId?.toUpperCase() === 'ETH'
   const token = useToken(isETH ? undefined : currencyId)
+  const extendedEther = useMemo(() => (chainId ? ExtendedEther.onChain(chainId) : undefined), [chainId])
   const weth = chainId ? WETH9_EXTENDED[chainId] : undefined
   if (weth?.address?.toLowerCase() === currencyId?.toLowerCase()) return weth
-  return isETH ? (chainId ? ExtendedEther.onChain(chainId) : undefined) : token
+  return isETH ? extendedEther : token
 }


### PR DESCRIPTION
`ExtendedEther.onChain` creates a new object from 'ETH' which causes dependencies to re-render
