### PR TITLE
fix: remove duplicate `set price range` title when there is liquidity

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -846,11 +846,13 @@ export default function AddLiquidity({
                       <StackedContainer>
                         <StackedItem style={{ opacity: showCapitalEfficiencyWarning ? '0.05' : 1 }}>
                           <AutoColumn gap="md">
-                            <RowBetween>
-                              <TYPE.label>
-                                <Trans>Set Price Range</Trans>
-                              </TYPE.label>
-                            </RowBetween>
+                            {noLiquidity && (
+                              <RowBetween>
+                                <TYPE.label>
+                                  <Trans>Set Price Range</Trans>
+                                </TYPE.label>
+                              </RowBetween>
+                            )}
                             <RangeSelector
                               priceLower={priceLower}
                               priceUpper={priceUpper}


### PR DESCRIPTION
Previously, `set price range` was duplicated when there was liquidity:

![image](https://user-images.githubusercontent.com/1284993/125710060-3b586f9a-1c38-4a3f-a9e0-8c73afcd3490.png)
