### PR TITLE
fix: toggle liquidity position when toggling rates

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -606,6 +606,7 @@ export default function AddLiquidity({
                     handleRateToggle={() => {
                       onLeftRangeInput((invertPrice ? priceLower : priceUpper?.invert())?.toSignificant(6) ?? '')
                       onRightRangeInput((invertPrice ? priceUpper : priceLower?.invert())?.toSignificant(6) ?? '')
+                      onFieldAInput(formattedAmounts[Field.CURRENCY_B] ?? '')
                       history.push(
                         `/add/${currencyIdB as string}/${currencyIdA as string}${feeAmount ? '/' + feeAmount : ''}`
                       )


### PR DESCRIPTION
If field A and field B are already populated, chances are the user wants them to remain the same and only wants to invert the price range selector.

The conversion isn't exact, but should be preferable to the previous behavior.