### PR TITLE
fix: update mobile header to fix overflow

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -192,14 +192,15 @@ const StyledNavLink = styled(NavLink).attrs({
   text-decoration: none;
   color: ${({ theme }) => theme.text2};
   font-size: 1rem;
-  width: fit-content;
   font-weight: 500;
   padding: 8px 12px;
   word-break: break-word;
-
+  overflow: hidden;
+  white-space: nowrap;
   &.${activeClassName} {
     border-radius: 12px;
     font-weight: 600;
+    justify-content: center;
     color: ${({ theme }) => theme.text1};
     background-color: ${({ theme }) => theme.bg2};
   }


### PR DESCRIPTION
This is to fix #2124  to remove setting the width, otherwise on small enough screens (Galaxy Fold 280px) the header would get cut off on the edges.