### PR TITLE
fix(config): update tsconfig, drop ie11/dead browsers support

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "start-server-and-test": "^1.11.0",
     "styled-components": "^5.3.0",
     "styled-system": "^5.1.5",
+    "tslib": "^2.3.0",
     "typechain": "^5.0.0",
     "typescript": "^4.2.3",
     "ua-parser-js": "^0.7.28",
@@ -148,9 +149,12 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
+      ">0.3%",
       "not dead",
-      "not op_mini all"
+      "not op_mini all",
+      "not IE > 0",
+      "not samsung 4",
+      "not and_uc 12.12"
     ],
     "development": [
       "last 1 chrome version",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "noImplicitReturns": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
+    "importHelpers": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "downlevelIteration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18381,7 +18381,7 @@ tslib@^2, tslib@^2.0.0, tslib@~2.2.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@~2.3.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==


### PR DESCRIPTION
### Changes

- [x] add `tslib` (or alt. remove `downlevelIteration` from tsconfig
- [x] update browserslist to explicitly not support IE11

#### 1. enable `importHelpers` 

> importHelpers flag is on, these helper functions are instead imported from the tslib module
> (...)
>Turning on `downlevelIteration` and `importHelpers` is still false - [typescript documentation, tsconfig](https://www.typescriptlang.org/tsconfig#importHelpers)


##### 2. update `browserslist` configuration


```bash
$ npx browserslist  ">0.2%, not dead, not op_mini all"
and_chr 90
and_ff 87
and_uc 12.12
android 4.4.3-4.4.4
chrome 90
chrome 89
chrome 88
chrome 87
chrome 86
chrome 85
chrome 49
edge 90
edge 89
firefox 88
firefox 87
ie 11
ios_saf 14.0-14.4
ios_saf 13.4-13.7
ios_saf 12.2-12.4
opera 75
opera 73
safari 14
safari 13.1
```

##### Updated browserslist configuration with explicit no IE11

```json
  "browserslist": {
    "production": [
      ">0.3%",
      "not dead",
      "not op_mini all",
      "not IE > 0",
      "not samsung 4",
      "not and_uc 12.12"
    ]
```

###### updated result:

```bash
$ npx browserslist
and_chr 90
chrome 90
chrome 89
chrome 88
chrome 87
edge 90
edge 89
firefox 88
firefox 87
ios_saf 14.0-14.4
ios_saf 13.4-13.7
opera 75
opera 73
safari 14
safari 13.1
samsung 14.0
samsung 13.0
```

