### PR TITLE
fix: avoid running BestV3Trade when tokens are the same

### DIFF
--- a/src/hooks/useBestV3Trade.ts
+++ b/src/hooks/useBestV3Trade.ts
@@ -48,7 +48,12 @@ export function useBestV3TradeExactIn(
   })
 
   return useMemo(() => {
-    if (!amountIn || !currencyOut) {
+    if (
+      !amountIn ||
+      !currencyOut ||
+      // skip when tokens are the same
+      !amountIn.currency.equals(currencyOut)
+    ) {
       return {
         state: V3TradeState.INVALID,
         trade: null,
@@ -132,7 +137,13 @@ export function useBestV3TradeExactOut(
   })
 
   return useMemo(() => {
-    if (!amountOut || !currencyIn || quotesResults.some(({ valid }) => !valid)) {
+    if (
+      !amountOut ||
+      !currencyIn ||
+      quotesResults.some(({ valid }) => !valid) ||
+      // skip when tokens are the same
+      !amountOut.currency.equals(currencyIn)
+    ) {
       return {
         state: V3TradeState.INVALID,
         trade: null,

--- a/src/hooks/useBestV3Trade.ts
+++ b/src/hooks/useBestV3Trade.ts
@@ -52,7 +52,7 @@ export function useBestV3TradeExactIn(
       !amountIn ||
       !currencyOut ||
       // skip when tokens are the same
-      !amountIn.currency.equals(currencyOut)
+      amountIn.currency.equals(currencyOut)
     ) {
       return {
         state: V3TradeState.INVALID,
@@ -142,7 +142,7 @@ export function useBestV3TradeExactOut(
       !currencyIn ||
       quotesResults.some(({ valid }) => !valid) ||
       // skip when tokens are the same
-      !amountOut.currency.equals(currencyIn)
+      amountOut.currency.equals(currencyIn)
     ) {
       return {
         state: V3TradeState.INVALID,


### PR DESCRIPTION
note. will update integration tests as a follow-up. We will probably need to set up the mainnet fork in integration tests to make this workable.