### PR TITLE
fix: cherry pick the logs hook fix from the liquidity incentives branch

### DIFF
--- a/src/state/logs/hooks.ts
+++ b/src/state/logs/hooks.ts
@@ -5,7 +5,7 @@ import { useAppDispatch, useAppSelector } from '../hooks'
 import { addListener, removeListener } from './slice'
 import { EventFilter, filterToKey, Log } from './utils'
 
-enum LogsState {
+export enum LogsState {
   // The filter is invalid
   INVALID,
   // The logs are being loaded
@@ -26,6 +26,7 @@ export interface UseLogsResult {
 /**
  * Returns the logs for the given filter as of the latest block, re-fetching from the library every block.
  * @param filter The logs filter, without `blockHash`, `fromBlock` or `toBlock` defined.
+ * The filter parameter should _always_ be memoized, or else will trigger constant refetching
  */
 export function useLogs(filter: EventFilter | undefined): UseLogsResult {
   const { chainId } = useActiveWeb3React()

--- a/src/state/logs/utils.ts
+++ b/src/state/logs/utils.ts
@@ -6,6 +6,9 @@ export interface EventFilter {
 export interface Log {
   topics: Array<string>
   data: string
+  transactionIndex: number
+  logIndex: number
+  blockNumber: number
 }
 
 /**
@@ -26,6 +29,7 @@ export function keyToFilter(key: string): EventFilter {
   const pcs = key.split(':')
   const address = pcs[0]
   const topics = pcs[1].split('-').map((topic) => {
+    if (topic === '\0') return null
     const parts = topic.split(';')
     if (parts.length === 1) return parts[0]
     return parts


### PR DESCRIPTION
`keyToFilter` had a bug fixed in that branch