### PR TITLE
fix: increase max block age for l2s

### DIFF
--- a/src/hooks/useFeeTierDistribution.ts
+++ b/src/hooks/useFeeTierDistribution.ts
@@ -11,7 +11,7 @@ import ms from 'ms.macro'
 import { PoolState, usePool } from './usePools'
 
 // maximum number of blocks past which we consider the data stale
-const MAX_DATA_BLOCK_AGE = 10
+const MAX_DATA_BLOCK_AGE = 20
 
 interface FeeTierDistribution {
   isLoading: boolean
@@ -85,7 +85,7 @@ function usePoolTVL(token0: Token | undefined, token1: Token | undefined) {
   const { isLoading, isFetching, isUninitialized, isError, data } = useFeeTierDistributionQuery(
     token0 && token1 ? { token0: token0.address.toLowerCase(), token1: token1.address.toLowerCase() } : skipToken,
     {
-      pollingInterval: ms`2m`,
+      pollingInterval: ms`30s`,
     }
   )
 

--- a/src/hooks/usePoolTickData.ts
+++ b/src/hooks/usePoolTickData.ts
@@ -31,11 +31,10 @@ export function useAllV3Ticks(
   const poolAddress =
     currencyA && currencyB && feeAmount ? Pool.getAddress(currencyA?.wrapped, currencyB?.wrapped, feeAmount) : undefined
 
-  //TODO(judo): determine if pagination is necessary for this query
   const { isLoading, isError, error, isUninitialized, data } = useAllV3TicksQuery(
     poolAddress ? { poolAddress: poolAddress?.toLowerCase(), skip: 0 } : skipToken,
     {
-      pollingInterval: ms`2m`,
+      pollingInterval: ms`30s`,
     }
   )
 


### PR DESCRIPTION
adjust freshness params for l2s

I don't think we need to differentiate between l2 and l1 right now