### PR TITLE
fix: ban esnext syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     }
   },
   "extends": [
+    "plugin:es/no-new-in-esnext",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react-hooks/recommended",
@@ -22,6 +23,7 @@
     "plugin:prettier/recommended"
   ],
   "rules": {
+    "es/no-numeric-separators": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "prettier/prettier": "error",
     "@typescript-eslint/no-explicit-any": "off",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "d3": "^7.0.0",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-es": "https://github.com/mysticatea/eslint-plugin-es#00d73851793541dc7b0d07292deb0ca2bc8a25e1",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "d3": "^7.0.0",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-es": "https://github.com/mysticatea/eslint-plugin-es#00d73851793541dc7b0d07292deb0ca2bc8a25e1",
+    "eslint-plugin-es": "mysticatea/eslint-plugin-es#00d73851793541dc7b0d07292deb0ca2bc8a25e1",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^4.0.0",

--- a/src/state/governance/hooks.ts
+++ b/src/state/governance/hooks.ts
@@ -135,7 +135,7 @@ function useFormattedProposalCreatedLogs(
 
           // Bravo proposal omits newlines
           if (startBlock === BRAVO_START_BLOCK) {
-            description = description.replaceAll(/  /g, '\n').replaceAll(/\d\. /g, '\n$&')
+            description = description.replace(/  /g, '\n').replace(/\d\. /g, '\n$&')
           }
         }
         return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9132,6 +9132,13 @@ eslint-module-utils@^2.6.1:
     debug "^3.2.7"
     pkg-dir "^2.0.0"
 
+"eslint-plugin-es@https://github.com/mysticatea/eslint-plugin-es#00d73851793541dc7b0d07292deb0ca2bc8a25e1":
+  version "4.1.0"
+  resolved "https://github.com/mysticatea/eslint-plugin-es#00d73851793541dc7b0d07292deb0ca2bc8a25e1"
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
 eslint-plugin-flowtype@^5.2.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-5.8.0.tgz#35b55e4ce559b90efbe913ed33630e391e301481"
@@ -16450,7 +16457,7 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9132,9 +9132,9 @@ eslint-module-utils@^2.6.1:
     debug "^3.2.7"
     pkg-dir "^2.0.0"
 
-"eslint-plugin-es@https://github.com/mysticatea/eslint-plugin-es#00d73851793541dc7b0d07292deb0ca2bc8a25e1":
+eslint-plugin-es@mysticatea/eslint-plugin-es#00d73851793541dc7b0d07292deb0ca2bc8a25e1:
   version "4.1.0"
-  resolved "https://github.com/mysticatea/eslint-plugin-es#00d73851793541dc7b0d07292deb0ca2bc8a25e1"
+  resolved "https://codeload.github.com/mysticatea/eslint-plugin-es/tar.gz/00d73851793541dc7b0d07292deb0ca2bc8a25e1"
   dependencies:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"


### PR DESCRIPTION
Fixes #2308

NB: Installs eslint-plugin-es from a commit instead of the published package, as the published package does not have support for prototypical methods (eg `String.prototype.replaceAll`).